### PR TITLE
Escape double quotes in string arguments

### DIFF
--- a/src/graphql_query/core.cljc
+++ b/src/graphql_query/core.cljc
@@ -34,7 +34,7 @@
           nil
           (arg->str [arg] "null")
           String
-          (arg->str [arg] (str "\"" arg "\""))
+          (arg->str [arg] (str "\"" (str/replace arg "\"" "\\\"") "\""))
           IPersistentMap
           (arg->str [arg] (str "{" (arguments->str arg) "}"))
           IPersistentCollection

--- a/src/graphql_query/core.cljc
+++ b/src/graphql_query/core.cljc
@@ -48,7 +48,7 @@
            nil
            (arg->str [arg] "null")
            string
-           (arg->str [arg] (str "\"" arg "\""))
+           (arg->str [arg] (str "\"" (str/replace arg "\"" "\\\"") "\""))
            PersistentArrayMap
            (arg->str [arg] (str "{" (arguments->str arg) "}"))
            PersistentHashMap

--- a/test/graphql_query/core_test.cljc
+++ b/test/graphql_query/core_test.cljc
@@ -37,6 +37,7 @@
   (is (= "id:1" (q/arguments->str {:id 1})))
   (is (= "id:null" (q/arguments->str {:id nil})))
   (is (= "id:1,type:\"human\"" (q/arguments->str {:id 1 :type "human"})))
+  (is (= "id:1,type:\"human \\\"being\\\"\"" (q/arguments->str {:id 1 :type "human \"being\""})))
   (is (= "id:1,vector:[1,2,3]" (q/arguments->str {:id 1 :vector [1 2 3]}))))
 
 (deftest meta-field->str


### PR DESCRIPTION
This fixes a bug whereby string argument values containing double quotes yield invalid graphql queries.