### PR TITLE
escape-chars: handle backslashes

### DIFF
--- a/src/graphql_query/core.cljc
+++ b/src/graphql_query/core.cljc
@@ -26,7 +26,7 @@
     (apply str)))
 
 (defn escape-chars [s]
-  (clojure.string/escape s {\" "\\\""}))
+  (clojure.string/escape s {\" "\\\"" \\ "\\\\"}))
 
 (defn sequential->str
   "Given something that is sequential format it to be like a JSON array."


### PR DESCRIPTION
Fixes that a malformed request is generated if there are backslashes in the query / mutation.